### PR TITLE
Rework features

### DIFF
--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -66,8 +66,6 @@
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.rest/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.rest.core/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.rest.sse/${project.version}</bundle>
-		<feature dependency="true">pax-web-jetty-http2</feature>
-		<feature dependency="true">pax-web-jetty-http2-jdk9</feature>
 	</feature>
 
 	<feature name="openhab-core-addon-marketplace" version="${project.version}">

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -71,17 +71,19 @@
 
 	<feature name="openhab.tp-httpclient" version="${project.version}">
 		<capability>openhab.tp;feature=httpclient;version=${jetty.version}</capability>
+		<feature dependency="true">pax-web-jetty-http2</feature>
+		<feature dependency="true">pax-web-jetty-http2-jdk9</feature>
 		<bundle dependency="true">mvn:javax.servlet/javax.servlet-api/3.1.0</bundle>
+		<bundle dependency="true">mvn:org.eclipse.jetty/jetty-alpn-client/${jetty.version}</bundle>
 		<bundle dependency="true">mvn:org.eclipse.jetty/jetty-client/${jetty.version}</bundle>
 		<bundle dependency="true">mvn:org.eclipse.jetty/jetty-http/${jetty.version}</bundle>
 		<bundle dependency="true">mvn:org.eclipse.jetty/jetty-util/${jetty.version}</bundle>
 		<bundle dependency="true">mvn:org.eclipse.jetty/jetty-io/${jetty.version}</bundle>
 		<bundle dependency="true">mvn:org.eclipse.jetty/jetty-proxy/${jetty.version}</bundle>
+		<bundle dependency="true">mvn:org.eclipse.jetty.http2/http2-client/${jetty.version}</bundle>
 		<bundle dependency="true">mvn:org.eclipse.jetty.websocket/websocket-api/${jetty.version}</bundle>
 		<bundle dependency="true">mvn:org.eclipse.jetty.websocket/websocket-common/${jetty.version}</bundle>
 		<bundle dependency="true">mvn:org.eclipse.jetty.websocket/websocket-client/${jetty.version}</bundle>
-		<feature dependency="true">pax-web-jetty-http2</feature>
-		<feature dependency="true">pax-web-jetty-http2-jdk9</feature>
 	</feature>
 
 	<feature name="openhab.tp-jackson" description="FasterXML Jackson bundles" version="${project.version}">


### PR DESCRIPTION
This should fix feature validation using the Pax Web features.
Some of the client bundles are unfortunately not part of the Pax Web features. :neutral_face: 
I think I'll create an issue for that in Pax Web to see if they can be added.